### PR TITLE
small corrections

### DIFF
--- a/Actions/StartRelationshipAction.cs
+++ b/Actions/StartRelationshipAction.cs
@@ -21,11 +21,13 @@ namespace Dramalord.Actions
 
             if(relationType == RelationshipType.Spouse)
             {
+                // Only the main hero keeps their old spouses - npcs are divorced!
                 if(hero != Hero.MainHero && hero.Spouse != null)
                 {
                     EndRelationshipAction.Apply(hero, hero.Spouse, hero.GetRelationTo(hero.Spouse));
                 }
 
+                // Only the main hero keeps their old spouses - npcs are divorced!
                 if (target != Hero.MainHero && target.Spouse != null)
                 {
                     EndRelationshipAction.Apply(target, target.Spouse, target.GetRelationTo(target.Spouse));

--- a/Behaviours/NpcCampaignBehavior.cs
+++ b/Behaviours/NpcCampaignBehavior.cs
@@ -98,7 +98,7 @@ namespace Dramalord.Behaviours
                                 target = hero.GetClosePrisoners().GetRandomElementWithPredicate(h =>
                                     hero.GetAttractionTo(h) >= DramalordMCM.Instance.MinAttraction
                                     && !hero.HasMetRecently(h)
-                                    && hero.CanPursueRomanceWith(h)   // EARLY FILTER
+                                    && (!hero.IsPlayerSpouse() || !DramalordMCM.Instance.PlayerSpouseFaithful)
                                 );
                                 if (target != null && new PrisonIntercourseIntention(target, hero, CampaignTime.Now).Action())
                                 {

--- a/Data/DramalordRelations.cs
+++ b/Data/DramalordRelations.cs
@@ -184,27 +184,8 @@ namespace Dramalord.Data
                 LegacySave.LoadLegacyRelations(_relations, dataStore);
             }
 
-            // Retroactively fix marriages.
-            // If OtherMarriageMod is active, update the vanilla spouse property based on Dramalord relations.
-            if (BetrothIntention.OtherMarriageModFound)
-            {
-                foreach (Hero hero in Hero.AllAliveHeroes)
-                {
-                    if (_relations.ContainsKey(hero))
-                    {
-                        hero.GetAllRelations().Do(kvp =>
-                        {
-                            Hero potentialSpouse = kvp.Key;
-                            HeroRelation relation = kvp.Value;
-                            if (relation.Relationship == RelationshipType.Spouse && hero.Spouse != potentialSpouse)
-                            {
-                                hero.Spouse = potentialSpouse;
-                            }
-                        });
-                    }
-                }
-            }
-            else
+            // also this is actually not necessary
+            if (!BetrothIntention.OtherMarriageModFound)
             {
                 // When not in compatibility mode, ensure that if the vanilla spouse is set, the Dramalord relation is correct.
                 Hero.AllAliveHeroes.Where(h => h.Spouse != null && _relations.ContainsKey(h)).Do(h =>

--- a/DramalordMCM.cs
+++ b/DramalordMCM.cs
@@ -54,7 +54,7 @@ namespace Dramalord
 
         [SettingPropertyGroup("{=Dramalord004}Hero Setup")]
         [SettingPropertyFloatingInteger("{=Dramalord005}Minimum Attraction", 0, 100, Order = 1, HintText = "{=Dramalord006}Attraction score required for NPCs to consider others as attractive", RequireRestart = false)]
-        public int MinAttraction { get; set; } = 50;
+        public int MinAttraction { get; set; } = 60;
 
         [SettingPropertyGroup("{=Dramalord004}Hero Setup")]
         [SettingPropertyFloatingInteger("{=Dramalord191}Minimum Dating Love", 0, 100, Order = 2, HintText = "{=Dramalord192}Love points required to consider dating a hero", RequireRestart = false)]

--- a/Extensions/HeroExtensions.cs
+++ b/Extensions/HeroExtensions.cs
@@ -89,7 +89,7 @@ namespace Dramalord.Extensions
             // If OtherMarriageMod is enabled, don't ignore Dramalord data completely—use it as a fallback
             if (BetrothIntention.OtherMarriageModFound)
             {
-                return hero.GetRelationTo(target).Relationship == RelationshipType.Spouse;
+                return GetRelationTo(hero, target).Relationship == RelationshipType.Spouse;
             }
 
             return false;
@@ -153,7 +153,7 @@ namespace Dramalord.Extensions
         // Determines if a hero is married to the player by checking both vanilla and internal systems.
         public static bool IsPlayerSpouse(this Hero hero)
         {
-            return hero.Spouse == Hero.MainHero || hero.IsSpouseOf(Hero.MainHero);
+            return hero.Spouse == Hero.MainHero; // not necessary to request Dramalord data!
         }
 
         // Determines whether a romance attempt is allowed between two heroes.
@@ -161,16 +161,22 @@ namespace Dramalord.Extensions
         {
             // Always allow romance if one party is the player.
             if (initiator == Hero.MainHero || target == Hero.MainHero)
+            {
                 return true;
+            }
 
             // If the Player Spouse Faithful setting is enabled,
             // block romance if either party is married to the player.
             if (DramalordMCM.Instance.PlayerSpouseFaithful && (initiator.IsPlayerSpouse() || target.IsPlayerSpouse()))
+            {
                 return false;
+            }
 
             // Block romance if either hero has a toy.
             if (initiator.GetDesires().HasToy || target.GetDesires().HasToy)
+            {
                 return false;
+            }
 
             // Otherwise, romance is allowed.
             return true;


### PR DESCRIPTION
Great work! Thanks again :)
I did a few corrections due to following reasons:

A NPC can be only married once - Only the player can have more spouses. The reason this is tracked for everyone is simply leaving the possibility open to implement something like truples or similar at a later time. I added comments to the part in the code where this is happening, so its visible in the review. Thus, when checking if a NPC is married to the player, a check on the property Hero.Spouse is sufficient.

Second thing is, you have to take care when modifying the Hero extension. On top you'll see cached data - which is the main thing keeping Dramalord more or less performant although many actions are happening. So when calling an extended method of a second hero (like some compatibility check) within a other extended method, and you're retrieving data like relations with it, the cache is filled with data of the second hero. So, when the loop continues, and you call again data from the first hero, the cache has to be refreshed again. This is a sensitive area, as Dictionary searches are very expensive. I'm pretty sure this can be optimized even further. 

Third is that the prisoner events should only check for the initiator being faithful, as the prisoner is basically a victim - there is no decision whether the prisoner likes the idea when its NPC & NPC, only the player get to pick on either side

Anyway, have a look at the changes - looking forward to your feedback!